### PR TITLE
feat: Implement MVT rendering for improved trip display performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ Shapely
 uvicorn[standard]
 jinja2
 python-multipart
+mercantile
+mapbox-vector-tile


### PR DESCRIPTION
Replaces GeoJSON with Mapbox Vector Tiles (MVT) for rendering trips on the main map, significantly improving performance and reducing CPU load, especially with large date ranges.

Key changes:

Backend (`app.py`):
- Added a new API endpoint `/api/trips/mvt/{z}/{x}/{y}.pbf`.
- This endpoint dynamically generates MVT tiles based on tile coordinates and date range query parameters.
- It queries MongoDB using geospatial intersection for the tile bounding box and filters by date.
- Trip data is encoded into PBF format using the `mapbox-vector-tile` library.
- Added `mercantile` and `mapbox-vector-tile` to `requirements.txt`.

Frontend (`static/js/app.js`):
- Modified the Mapbox GL JS integration to use a `vector` source pointing to the new MVT endpoint.
- The `tiles` URL for the vector source is dynamically updated when the date range changes.
- Adapted map update logic to work with vector tiles; Mapbox GL JS now handles tile fetching.
- Ensured the `source-layer` is correctly specified for the trips layer.
- Popups and existing styling are maintained by including necessary properties in MVT attributes.
- GeoJSON fetching (`/api/export/trips`) is retained for the trips table and metrics display to minimize disruption to other functionalities.

This change addresses the performance bottleneck on the main application page when displaying trip data on the map.