### PR TITLE
Improve page navigation responsiveness

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,0 +1,43 @@
+// Prefetch linked pages and show loading overlay on navigation
+(() => {
+  const CACHE_NAME = 'everystreet-pages-v1';
+
+  function prefetch(url) {
+    if (!('caches' in window)) return;
+    caches.open(CACHE_NAME).then(cache => {
+      cache.match(url).then(match => {
+        if (!match) {
+          fetch(url, { credentials: 'same-origin' })
+            .then(resp => resp.ok && cache.put(url, resp.clone()))
+            .catch(() => {});
+        }
+      });
+    });
+  }
+
+  function attachPrefetch(link) {
+    const url = link.href;
+    if (!url.startsWith(window.location.origin)) return;
+    const handle = () => prefetch(url);
+    link.addEventListener('mouseenter', handle, { passive: true });
+    link.addEventListener('focus', handle, { passive: true });
+    link.addEventListener('touchstart', handle, { passive: true, once: true });
+    link.addEventListener('click', () => {
+      window.loadingManager?.show('Loading...');
+    });
+  }
+
+  function init() {
+    const links = document.querySelectorAll('a');
+    links.forEach(attachPrefetch);
+    window.addEventListener('pageshow', () => {
+      window.loadingManager?.hide();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -1,8 +1,28 @@
 const CACHE_NAME = "everystreet-ui-v1";
+const PAGE_CACHE = "everystreet-pages-v1";
 const API_PATTERN = /\/api\//;
 const TILE_PATTERN = /basemaps\.cartocdn\.com/;
 
+const PAGE_URLS = [
+  '/',
+  '/trips',
+  '/edit_trips',
+  '/settings',
+  '/driving-insights',
+  '/driver-behavior',
+  '/driving-navigation',
+  '/coverage-management',
+  '/export',
+  '/upload',
+  '/database-management',
+  '/visits',
+  '/app-settings'
+];
+
 self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(PAGE_CACHE).then((cache) => cache.addAll(PAGE_URLS))
+  );
   self.skipWaiting();
 });
 
@@ -16,11 +36,27 @@ self.addEventListener("activate", (event) => {
 self.addEventListener("fetch", (event) => {
   const { request } = event;
   if (request.method !== "GET") return;
-  if (!request.url.match(API_PATTERN) && !request.url.match(TILE_PATTERN))
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirst(request));
     return;
-
-  event.respondWith(staleWhileRevalidate(request));
+  }
+  if (request.url.match(API_PATTERN) || request.url.match(TILE_PATTERN)) {
+    event.respondWith(staleWhileRevalidate(request));
+  }
 });
+
+async function networkFirst(request) {
+  const cache = await caches.open(PAGE_CACHE);
+  try {
+    const resp = await fetch(request);
+    cache.put(request, resp.clone());
+    return resp;
+  } catch (err) {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    throw err;
+  }
+}
 
 async function staleWhileRevalidate(request) {
   const cache = await caches.open(CACHE_NAME);

--- a/templates/base.html
+++ b/templates/base.html
@@ -926,6 +926,10 @@
     ></script>
     <script
       defer
+      src="{{ url_for('static', path='js/navigation.js') | replace('http://', '//') }}"
+    ></script>
+    <script
+      defer
       src="{{ url_for('static', path='js/app.js') | replace('http://', '//') }}"
     ></script>
     <script


### PR DESCRIPTION
## Summary
- add page caching to service worker and pre-cache core pages
- prefetch pages and display a loading overlay via new `navigation.js`
- load new script from `base.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f6c062d60833189b6d0b831a87adc