### PR TITLE
Add local MongoDB service and conditional TLS configuration

### DIFF
--- a/db.py
+++ b/db.py
@@ -115,23 +115,32 @@ class DatabaseManager:
                 raise ValueError("MONGO_URI environment variable not set")
 
             logger.debug("Initializing MongoDB client...")
+
+            client_kwargs: dict[str, Any] = {
+                "tz_aware": True,
+                "tzinfo": timezone.utc,
+                "maxPoolSize": self._max_pool_size,
+                "minPoolSize": 0,
+                "maxIdleTimeMS": 60000,
+                "connectTimeoutMS": self._connection_timeout_ms,
+                "serverSelectionTimeoutMS": self._server_selection_timeout_ms,
+                "socketTimeoutMS": self._socket_timeout_ms,
+                "retryWrites": True,
+                "retryReads": True,
+                "waitQueueTimeoutMS": 10000,
+                "appname": "EveryStreet",
+            }
+
+            if mongo_uri.startswith("mongodb+srv://"):
+                client_kwargs.update(
+                    tls=True,
+                    tlsAllowInvalidCertificates=True,
+                    tlsCAFile=certifi.where(),
+                )
+
             self._client = AsyncIOMotorClient(
                 mongo_uri,
-                tls=True,
-                tlsAllowInvalidCertificates=True,
-                tlsCAFile=certifi.where(),
-                tz_aware=True,
-                tzinfo=timezone.utc,
-                maxPoolSize=self._max_pool_size,
-                minPoolSize=0,
-                maxIdleTimeMS=60000,
-                connectTimeoutMS=self._connection_timeout_ms,
-                serverSelectionTimeoutMS=self._server_selection_timeout_ms,
-                socketTimeoutMS=self._socket_timeout_ms,
-                retryWrites=True,
-                retryReads=True,
-                waitQueueTimeoutMS=10000,
-                appname="EveryStreet",
+                **client_kwargs,
             )
             self._db = self._client[self._db_name]
             self._connection_healthy = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -18,6 +18,7 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
       - worker
       - beat
@@ -26,8 +27,8 @@ services:
     build: .
     command: celery -A celery_app worker --loglevel=info
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -37,14 +38,15 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
 
   beat:
     build: .
     command: celery -A celery_app beat --loglevel=info
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -54,6 +56,7 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
 
   redis:
@@ -63,5 +66,13 @@ services:
     volumes:
       - redis_data:/data
 
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
 volumes:
   redis_data:
+  mongo_data:


### PR DESCRIPTION
## Summary
- add a local MongoDB service with persistent storage to docker-compose and ensure the app services depend on it
- provide default Redis and MongoDB URIs for docker-compose to simplify local configuration
- update the MongoDB client initialization to only enable TLS when connecting to mongodb+srv URLs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa784c917c8331b77b6323bf8ef63a 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a local MongoDB service with persistent storage to the docker-compose setup, streamlining application service dependencies. It also includes default Redis and MongoDB URIs for easier local configuration and updates MongoDB client initialization to enable TLS for mongodb+srv connections.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MongoDB 7 service to Docker Compose environment with data persistence
  * Configured default environment variables for Redis and MongoDB connections
  * Enhanced MongoDB connection handling with conditional TLS configuration for secure URI schemes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->