### PR TITLE
Default to local Redis and MongoDB for local runs

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -38,11 +38,12 @@ if not REDIS_URL:
 
     if redis_host and redis_password:
         REDIS_URL = f"redis://{redis_user}:{redis_password}@{redis_host}:{redis_port}"
+        logger.info("Constructed REDIS_URL from component variables.")
     else:
-        raise ValueError(
-            "REDIS_URL environment variable is not set and cannot be constructed! "
-            "This is required for Celery to connect to Redis broker. "
-            "Please configure REDIS_URL in your environment (e.g., Railway).",
+        REDIS_URL = "redis://localhost:6379"
+        logger.warning(
+            "REDIS_URL not provided; defaulting to local Redis at %s.",
+            REDIS_URL,
         )
 
 logger.info(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -18,16 +18,15 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
-      - worker
-      - beat
 
   worker:
     build: .
     command: celery -A celery_app worker --loglevel=info
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -37,14 +36,15 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
 
   beat:
     build: .
     command: celery -A celery_app beat --loglevel=info
     environment:
-      - REDIS_URL=${REDIS_URL}
-      - MONGO_URI=${MONGO_URI}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/every_street}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - REDIRECT_URI=${REDIRECT_URI}
@@ -54,6 +54,7 @@ services:
     volumes:
       - .:/app
     depends_on:
+      - mongo
       - redis
 
   redis:
@@ -63,5 +64,13 @@ services:
     volumes:
       - redis_data:/data
 
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
 volumes:
   redis_data:
+  mongo_data:

--- a/start.sh
+++ b/start.sh
@@ -49,8 +49,15 @@ if [ -z "$REDIS_URL" ]; then
     export REDIS_URL="redis://default:${REDISPASSWORD}@${REDISHOST}:${REDISPORT:-6379}"
     echo "Constructed REDIS_URL from component variables"
   else
-    echo "WARNING: REDIS_URL not set and cannot be constructed!"
+    export REDIS_URL="redis://localhost:6379"
+    echo "Using default local Redis URL: $REDIS_URL"
   fi
+fi
+
+# Ensure MONGO_URI defaults to local instance if not set
+if [ -z "$MONGO_URI" ]; then
+  export MONGO_URI="mongodb://localhost:27017/every_street"
+  echo "Using default local MongoDB URI: $MONGO_URI"
 fi
 
 # Create a non-root user for Celery if we're running as root

--- a/update_geo_points.py
+++ b/update_geo_points.py
@@ -258,8 +258,11 @@ if __name__ == "__main__":
 
     MONGO_URI = os.environ.get("MONGO_URI")
     if not MONGO_URI:
-        logger.error("MONGO_URI environment variable not set")
-        sys.exit(1)
+        MONGO_URI = "mongodb://localhost:27017/every_street"
+        logger.warning(
+            "MONGO_URI environment variable not set; defaulting to local MongoDB at %s",
+            MONGO_URI,
+        )
 
     client = AsyncIOMotorClient(MONGO_URI, tz_aware=True)
     db = client["every_street"]


### PR DESCRIPTION
## Summary
- default Redis configuration to the local container when service variables are absent
- fall back to the local MongoDB instance for scripts and the database manager when no URI is provided
- ensure docker-compose web service only depends on the infrastructure services and update start.sh defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa784c917c8331b77b6323bf8ef63a 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces default configurations for Redis and MongoDB to streamline local development. It updates the start.sh script to ensure a smoother setup when environment variables are not set, reducing configuration overhead.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application no longer crashes when Redis or MongoDB URLs are missing; now defaults to local instances with warning logs.

* **New Features**
  * Added MongoDB service to Docker Compose for streamlined local development setup.
  * Enhanced MongoDB connection configuration with improved connection pooling and TLS support for production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->