### PR TITLE
refactor: Remove 310+ lines of duplicate CSS code

### DIFF
--- a/static/css/loading-styles.css
+++ b/static/css/loading-styles.css
@@ -180,11 +180,7 @@ body.light-mode .loading-overlay {
   border-right-color: transparent !important;
 }
 
-@keyframes btn-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* Note: @keyframes btn-spin moved to animations.css */
 
 /* === Skeleton Loading === */
 .skeleton-loader {
@@ -220,15 +216,7 @@ body.light-mode .skeleton-loader::after {
   background-color: var(--surface-4);
 }
 
-@keyframes skeleton-shine {
-  0% {
-    background-position: -200% 0;
-  }
-
-  100% {
-    background-position: 200% 0;
-  }
-}
+/* Note: @keyframes skeleton-shine moved to animations.css */
 
 .skeleton-text {
   /* Apply to text-like skeleton elements */

--- a/static/css/modern-map.css
+++ b/static/css/modern-map.css
@@ -298,19 +298,7 @@ body.light-mode .mapboxgl-ctrl-compass .mapboxgl-ctrl-icon {
   transform: scale(1.2);
 }
 
-@keyframes pulse-marker {
-  /* Renamed from pulse to avoid conflict */
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-
-  50% {
-    transform: scale(1.1);
-    opacity: 0.8;
-  }
-}
+/* Note: @keyframes pulse-marker moved to animations.css */
 
 /* === Feature Styling (Trips, Streets) === */
 .trip-path {

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -56,17 +56,7 @@
   will-change: transform;
 }
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
+/* Note: @keyframes slideDown moved to animations.css */
 
 /* When dropdown appears above the input */
 .search-results-dropdown.above {
@@ -224,11 +214,7 @@
   vertical-align: middle;
 }
 
-@keyframes search-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* Note: @keyframes search-spin moved to animations.css */
 
 /* Scrollbar styling for dropdown */
 .search-results-dropdown::-webkit-scrollbar {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1347,18 +1347,7 @@ body.light-mode .table-striped tbody tr:nth-of-type(odd) {
   animation: pulse-indicator 1.5s infinite ease-in-out;
 }
 
-@keyframes pulse-indicator {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.7;
-    transform: scale(0.8);
-  }
-}
+/* Note: @keyframes pulse-indicator moved to animations.css */
 
 /* === Enhanced Live Trip Metrics Styling === */
 .live-tracking-status {
@@ -1661,18 +1650,7 @@ body.light-mode .table-striped tbody tr:nth-of-type(odd) {
   pointer-events: none;
 }
 
-@keyframes pulse-hero {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.6;
-  }
-
-  50% {
-    transform: scale(1.05);
-    opacity: 0.4;
-  }
-}
+/* Note: @keyframes pulse-hero moved to animations.css */
 
 .hero-section h1 {
   font-size: var(--font-size-3xl);
@@ -1831,15 +1809,7 @@ body.light-mode .hero-section::before {
   color: var(--danger);
 }
 
-@keyframes error-pulse {
-  from {
-    transform: scale(1);
-  }
-
-  to {
-    transform: scale(1.05);
-  }
-}
+/* Note: @keyframes error-pulse moved to animations.css */
 
 /* Alerts (Enhanced from coverage_management.html) */
 .alert {
@@ -2064,160 +2034,7 @@ body.light-mode .btn-close-white {
   color: var(--text-on-primary) !important;
 }
 
-/* Add other .bg-color utilities as needed */
-
-.text-center {
-  text-align: center !important;
-}
-
-.text-start {
-  text-align: left !important;
-} /* Assuming LTR */
-.text-end {
-  text-align: right !important;
-} /* Assuming LTR */
-
-.mb-1 {
-  margin-bottom: var(--space-1) !important;
-}
-
-.mb-2 {
-  margin-bottom: var(--space-2) !important;
-}
-
-.mb-3 {
-  margin-bottom: var(--space-3) !important;
-}
-
-.mb-4 {
-  margin-bottom: var(--space-4) !important;
-}
-
-.mb-5 {
-  margin-bottom: var(--space-5) !important;
-}
-
-.mt-1 {
-  margin-top: var(--space-1) !important;
-}
-
-.mt-2 {
-  margin-top: var(--space-2) !important;
-}
-
-.mt-3 {
-  margin-top: var(--space-3) !important;
-}
-
-.mt-4 {
-  margin-top: var(--space-4) !important;
-}
-
-.mt-5 {
-  margin-top: var(--space-5) !important;
-}
-
-/* Add other margin/padding utilities (mx, my, p-*, pt-*, etc.) as needed */
-
-.p-0 {
-  padding: 0 !important;
-}
-
-.p-1 {
-  padding: var(--space-1) !important;
-}
-
-.p-2 {
-  padding: var(--space-2) !important;
-}
-
-.p-3 {
-  padding: var(--space-3) !important;
-}
-
-.p-4 {
-  padding: var(--space-4) !important;
-}
-
-.d-none {
-  display: none !important;
-}
-
-.d-inline {
-  display: inline !important;
-}
-
-.d-inline-block {
-  display: inline-block !important;
-}
-
-.d-block {
-  display: block !important;
-}
-
-.d-flex {
-  display: flex !important;
-}
-
-.d-inline-flex {
-  display: inline-flex !important;
-}
-
-.justify-content-start {
-  justify-content: flex-start !important;
-}
-
-.justify-content-end {
-  justify-content: flex-end !important;
-}
-
-.justify-content-center {
-  justify-content: center !important;
-}
-
-.justify-content-between {
-  justify-content: space-between !important;
-}
-
-.justify-content-around {
-  justify-content: space-around !important;
-}
-
-.justify-content-evenly {
-  justify-content: space-evenly !important;
-}
-
-.align-items-start {
-  align-items: flex-start !important;
-}
-
-.align-items-end {
-  align-items: flex-end !important;
-}
-
-.align-items-center {
-  align-items: center !important;
-}
-
-.align-items-baseline {
-  align-items: baseline !important;
-}
-
-.align-items-stretch {
-  align-items: stretch !important;
-}
-
-.flex-grow-1 {
-  flex-grow: 1 !important;
-}
-
-.w-100 {
-  width: 100% !important;
-}
-
-.h-100 {
-  height: 100% !important;
-}
+/* Note: Utility classes moved to utilities.css */
 
 .text-truncate {
   overflow: hidden;
@@ -2239,43 +2056,19 @@ body.light-mode .btn-close-white {
 }
 
 /* === Animations === */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
+/* Note: All @keyframes moved to animations.css */
 
 .fade-in {
   animation: fadeIn 0.3s ease forwards;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .slide-up {
   animation: slideUp 0.4s ease forwards;
 }
 
-/* Note: @keyframes slideInDown moved to animations.css */
-
 .slide-in-down {
   animation: slideInDown 0.4s ease forwards;
 }
-
-/* Note: @keyframes spin moved to animations.css */
 
 .spinner {
   animation: spin 0.8s linear infinite;
@@ -2858,18 +2651,7 @@ body.light-mode .btn-close-white {
     animation: mobile-pulse 2s infinite;
   }
 
-  @keyframes mobile-pulse {
-    0%,
-    100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-
-    50% {
-      opacity: 0.6;
-      transform: scale(0.9);
-    }
-  }
+  /* Note: @keyframes mobile-pulse moved to animations.css */
 
   /* Metrics grid */
   .mobile-metrics-grid {
@@ -3109,16 +2891,7 @@ body.light-mode .btn-close-white {
     animation: mobile-bounce 2s infinite;
   }
 
-  @keyframes mobile-bounce {
-    0%,
-    100% {
-      transform: translateY(0);
-    }
-
-    50% {
-      transform: translateY(-4px);
-    }
-  }
+  /* Note: @keyframes mobile-bounce moved to animations.css */
 
   .mobile-bottom-sheet:not(.collapsed) .mobile-sheet-expand-hint {
     display: none;

--- a/static/css/visits.css
+++ b/static/css/visits.css
@@ -69,16 +69,7 @@
   opacity: 0.15;
 }
 
-@keyframes gradient-shift {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-}
+/* Note: @keyframes gradient-shift moved to animations.css */
 
 /* Enhanced Place Management Panel */
 .place-management-panel {
@@ -108,18 +99,7 @@
   pointer-events: none;
 }
 
-@keyframes pulse-subtle {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.5;
-  }
-
-  50% {
-    transform: scale(1.1);
-    opacity: 0.3;
-  }
-}
+/* Note: @keyframes pulse-subtle moved to animations.css */
 
 /* Enhanced Form Controls */
 .place-name-input {
@@ -179,16 +159,7 @@
   animation: pulse-draw 2s ease-in-out infinite;
 }
 
-@keyframes pulse-draw {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-
-  50% {
-    transform: scale(1.02);
-  }
-}
+/* Note: @keyframes pulse-draw moved to animations.css */
 
 /* Enhanced Chart Container */
 .chart-container {
@@ -221,11 +192,7 @@
   pointer-events: none;
 }
 
-@keyframes rotate-slow {
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* Note: @keyframes rotate-slow moved to animations.css */
 
 /* Enhanced Table Styles */
 .visits-table {
@@ -465,15 +432,7 @@
   margin-bottom: var(--space-2);
 }
 
-@keyframes loading {
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
-  }
-}
+/* Note: @keyframes loading moved to animations.css */
 
 /* Responsive Enhancements */
 @media (width <= 992px) {
@@ -571,11 +530,7 @@
   transform-origin: center;
 }
 
-@keyframes progress-fill {
-  to {
-    stroke-dashoffset: 0;
-  }
-}
+/* Note: @keyframes progress-fill moved to animations.css */
 
 /* Divider Gradient (extracted from bottom inline style) */
 .divider-gradient {


### PR DESCRIPTION
This commit removes redundant CSS that is now centralized in animations.css and utilities.css. This brings the overall refactoring from +1130/-275 (+855 net) to a much more reasonable +1130/-603 (+527 net).

## Removed Duplicate Utility Classes (151 lines)
**From style.css:**
- Text alignment (.text-center, .text-start, .text-end)
- Display utilities (.d-none, .d-block, .d-flex, .d-inline, etc.)
- Flexbox utilities (.justify-content-*, .align-items-*)
- Margin utilities (.mb-1 through .mb-5, .mt-1 through .mt-5)
- Padding utilities (.p-0 through .p-4)
- Sizing utilities (.w-100, .h-100)

All these are now in utilities.css with better organization.

## Removed Duplicate Animations (177 lines)

**From style.css (44 lines):**
- @keyframes fadeIn (9 lines)
- @keyframes slideUp (11 lines)
- @keyframes slideInDown (removed earlier)
- @keyframes spin (removed earlier)
- @keyframes pulse-indicator (12 lines)
- @keyframes pulse-hero (12 lines)
- @keyframes error-pulse (9 lines)
- @keyframes mobile-pulse (12 lines)
- @keyframes mobile-bounce (10 lines)

**From visits.css (51 lines):**
- @keyframes gradient-shift (10 lines)
- @keyframes pulse-subtle (12 lines)
- @keyframes pulse-draw (10 lines)
- @keyframes rotate-slow (5 lines)
- @keyframes loading (9 lines)
- @keyframes progress-fill (5 lines)

**From search.css (15 lines):**
- @keyframes slideDown (10 lines)
- @keyframes search-spin (5 lines)

**From loading-styles.css (14 lines):**
- @keyframes btn-spin (5 lines)
- @keyframes skeleton-shine (9 lines)

**From modern-map.css (13 lines):**
- @keyframes pulse-marker (13 lines)

**From coverage-management.css:**
- Removed earlier in first commit

All animations now reference the centralized animations.css file.

## Impact
- **Eliminated 328 lines of duplicate code**
- **Added only 18 lines of reference comments**
- **Net change: -310 lines**
- **Combined with first commit: +1148/-603 = +545 net** (much better than +855!)

## Benefits
✅ Single source of truth for all animations and utilities ✅ Easier maintenance - update in one place
✅ Smaller CSS bundle size
✅ No more conflicting animation definitions
✅ Better code organization
✅ Faster development with reusable utilities 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request removes over 310 lines of duplicate CSS code, particularly keyframes and utility classes, which have been centralized into animations.css and utilities.css.</li>

<li>The changes eliminate redundant utility classes and animation keyframes, leading to a more organized and maintainable codebase.</li>

<li>The overall impact is a significant reduction in CSS size, improving performance and development efficiency.</li>

<li>Overall, this pull request touches on CSS organization and maintainability, resulting in a net reduction of 310 lines of code and improved performance.</li>

</ul>

</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CSS code structure by consolidating animations into a dedicated stylesheet and moving utility classes for improved maintainability and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->