### PR TITLE
Fix desktop view switching issue

### DIFF
--- a/static/js/map-mobile.js
+++ b/static/js/map-mobile.js
@@ -104,6 +104,8 @@ class MobileMapInterface {
     this.desktopLocation = document.getElementById("streets-location");
     this.mobileLayerContainer = document.getElementById("mobile-layer-toggles");
     this.desktopLayerContainer = document.getElementById("layer-toggles");
+    this.mobileMapType = document.getElementById("mobile-map-type-select");
+    this.desktopMapType = document.getElementById("map-type-select");
   }
 
   addBodyClass() {
@@ -458,6 +460,7 @@ class MobileMapInterface {
     this.syncSearchField();
     this.syncStreetModes();
     this.syncLiveTracking();
+    this.syncMapType();
   }
 
   syncMetrics(detail) {
@@ -603,6 +606,11 @@ class MobileMapInterface {
     this.updateMobileClearButton();
   }
 
+  syncMapType() {
+    if (!this.desktopMapType || !this.mobileMapType) return;
+    this.mobileMapType.value = this.desktopMapType.value;
+  }
+
   syncStreetModes() {
     const desktopButtons = document.querySelectorAll(".street-mode-btn");
     if (!desktopButtons.length) return;
@@ -662,6 +670,7 @@ class MobileMapInterface {
     this.setupSearchBridge();
     this.setupHighlightBridge();
     this.setupLocationBridge();
+    this.setupMapTypeBridge();
     this.attachLayerObserver();
     this.attachLocationObserver();
     this.attachStreetModeListeners();
@@ -782,6 +791,34 @@ class MobileMapInterface {
     );
     this.cleanupCallbacks.push(() =>
       this.desktopLocation.removeEventListener("change", desktopHandler)
+    );
+  }
+
+  setupMapTypeBridge() {
+    if (!this.desktopMapType || !this.mobileMapType) return;
+    const key = "mapType";
+
+    const mobileHandler = (event) => {
+      this.syncGuards[key] = "mobile";
+      this.desktopMapType.value = event.target.value;
+      this.desktopMapType.dispatchEvent(new Event("change", { bubbles: true }));
+      requestAnimationFrame(() => {
+        this.syncGuards[key] = null;
+      });
+    };
+
+    const desktopHandler = (event) => {
+      if (this.syncGuards[key] === "mobile") return;
+      this.mobileMapType.value = event.target.value;
+    };
+
+    this.mobileMapType.addEventListener("change", mobileHandler);
+    this.desktopMapType.addEventListener("change", desktopHandler);
+    this.cleanupCallbacks.push(() =>
+      this.mobileMapType.removeEventListener("change", mobileHandler)
+    );
+    this.cleanupCallbacks.push(() =>
+      this.desktopMapType.removeEventListener("change", desktopHandler)
     );
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -468,10 +468,19 @@ block content %}
           <div class="mobile-section-header">
             <h3 class="mobile-section-title">Map Layers</h3>
           </div>
+
+          <!-- Map Style Selector -->
+          <select id="mobile-map-type-select" class="mobile-select mb-3" aria-label="Select map style">
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+            <option value="satellite">Satellite</option>
+            <option value="streets">Streets</option>
+          </select>
+
           <div class="mobile-layer-buttons" id="mobile-layer-toggles">
             <!-- Layer buttons populated by JS -->
           </div>
-          
+
           <div class="mobile-toggle">
             <span class="mobile-toggle-label">Highlight Recent</span>
             <input type="checkbox" id="mobile-highlight-recent" checked />


### PR DESCRIPTION
Added the ability for mobile users to switch between Dark, Light, Satellite, and Streets map styles, matching the functionality already available on desktop.

Changes:
- Added mobile-map-type-select dropdown to mobile sheet in index.html
- Added syncMapType() function to sync mobile and desktop selectors
- Added setupMapTypeBridge() to enable bidirectional sync between mobile and desktop
- Integrated map type sync into the mobile interface initialization flow 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a new feature that allows mobile users to switch between different map styles, including Dark, Light, Satellite, and Streets.</li>

<li>Key changes include the addition of a dropdown for map style selection in the mobile interface and the implementation of synchronization logic to ensure that changes in one interface reflect in the other.</li>

<li>Overall, this enhances the user experience for mobile users by providing more control over map presentation.</li>

</ul>

</div>