### PR TITLE
feat: Add copy functionality and fix filter button in server logs

### DIFF
--- a/templates/server_logs.html
+++ b/templates/server_logs.html
@@ -107,11 +107,14 @@ block content %}
             <button id="auto-refresh-toggle" class="btn btn-outline-success">
               <i class="fas fa-clock"></i> Auto-Refresh: OFF
             </button>
-            <button id="clear-logs" class="btn btn-danger">
-              <i class="fas fa-trash"></i> Clear All Logs
+            <button id="copy-all-logs" class="btn btn-info">
+              <i class="fas fa-copy"></i> Copy All
             </button>
             <button id="export-logs" class="btn btn-secondary">
               <i class="fas fa-download"></i> Export
+            </button>
+            <button id="clear-logs" class="btn btn-danger">
+              <i class="fas fa-trash"></i> Clear All
             </button>
           </div>
         </div>
@@ -174,6 +177,22 @@ block content %}
 
   .log-entry:hover {
     background-color: rgba(255, 255, 255, 0.05);
+  }
+
+  .log-entry:hover .copy-log-btn {
+    opacity: 1;
+  }
+
+  .copy-log-btn {
+    opacity: 0.6;
+    transition: opacity 0.2s;
+    min-width: 36px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .copy-log-btn:hover {
+    opacity: 1;
   }
 
   .log-entry.log-DEBUG {


### PR DESCRIPTION
Enhancements:
- Added copy button to each individual log entry for quick copying
- Added "Copy All" button to copy all visible logs to clipboard
- Fixed apply filters button by adding preventDefault to all button handlers
- Copy buttons show visual feedback (checkmark and color change) on success
- Copy buttons fade in on hover for cleaner UI
- Formatted copied text includes timestamp, level, logger, message, location, and exceptions
- Copy All feature includes header with generation time and log count

The apply button now works correctly without needing to press Enter. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces significant enhancements to the server logs functionality, including a new copy button for each log entry and a 'Copy All' button for copying all visible logs.</li>

<li>Visual feedback for the copy buttons has been implemented to improve user experience.</li>

<li>The event handling for the apply filters button has been fixed to ensure it works correctly without requiring the Enter key.</li>

<li>Overall, this pull request introduces new features and fixes related to server logs, enhancing usability and accessibility.</li>

</ul>

</div>