### PR TITLE
Fix errors and related issues

### DIFF
--- a/live_tracking.py
+++ b/live_tracking.py
@@ -427,7 +427,7 @@ async def process_trip_end(
 
 async def get_active_trip() -> dict[str, Any] | None:
     """Get the currently active trip."""
-    if not live_trips_collection_global:
+    if live_trips_collection_global is None:
         logger.error("Live trips collection not initialized")
         return None
 


### PR DESCRIPTION
PyMongo Collection objects don't support truth value testing. Changed `if not live_trips_collection_global:` to
`if live_trips_collection_global is None:` to fix the error: "Collection objects do not implement truth value testing or bool()"

Fixes error in live_tracking.py:430 that was causing trip_updates API failures. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request addresses a bug in the live_tracking.py file related to truth value testing of PyMongo Collection objects, preventing errors that were causing failures in the trip_updates API.</li>

<li>The change ensures that the check for the initialization of the live_trips_collection_global variable is done correctly.</li>

<li>Overall, this fix enhances the stability of the application by resolving critical issues.</li>

</ul>

</div>