### PR TITLE
Improve trips datatable robustness

### DIFF
--- a/db.py
+++ b/db.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from fastapi import Request
     from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
 
-from date_utils import normalize_calendar_date, normalize_to_utc_datetime
+from date_utils import parse_timestamp, normalize_calendar_date, normalize_to_utc_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -509,10 +509,15 @@ optimal_route_progress_collection = _get_collection("optimal_route_progress")
 
 
 def serialize_datetime(
-    dt: datetime | None,
+    dt: datetime | str | None,
 ) -> str | None:
     if dt is None:
         return None
+    if isinstance(dt, str):
+        parsed = parse_timestamp(dt)
+        if parsed is None:
+            return None
+        dt = parsed
     dt = dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
     return dt.isoformat().replace("+00:00", "Z")
 


### PR DESCRIPTION
## Summary
- harden trips datatable request handling and numeric parsing to avoid server errors
- normalize trip timestamps and fuel values before computing durations and costs
- suppress DataTables alert popups and surface AJAX issues through in-page messaging

## Testing
- python -m compileall


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f5c2adc4c8331a18f219b947ba2fe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when trip data fails to load, replacing default alerts with user-friendly notifications
  * Enhanced robustness of timestamp and numeric data handling to gracefully manage malformed input
  * Strengthened API input validation for trips to ensure data integrity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->