### PR TITLE
Use `CollectionProxy` in admin_api to avoid stale MongoClient errors

### DIFF
--- a/admin_api.py
+++ b/admin_api.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Body, HTTPException, status
 
 from date_utils import ensure_utc
 from db import (
+    CollectionProxy,
     db_manager,
     delete_many_with_retry,
     find_one_with_retry,
@@ -23,8 +24,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Collections
-trips_collection = db_manager.db["trips"]
-app_settings_collection = db_manager.db["app_settings"]
+trips_collection = CollectionProxy("trips")
+app_settings_collection = CollectionProxy("app_settings")
 
 # Default settings if none stored
 DEFAULT_APP_SETTINGS: dict[str, Any] = {


### PR DESCRIPTION
### Motivation
- Error logs showed `pymongo.errors.InvalidOperation: Cannot use MongoClient after close` when API handlers reused collection objects bound to a closed client.
- Holding collection instances from `db_manager.db[...]` can retain stale client handles across event-loop or connection changes.
- The intent is to ensure collections are resolved against the current `DatabaseManager` client to avoid intermittent DB errors.

### Description
- Import `CollectionProxy` from `db` and replace direct `db_manager.db["trips"]` and `db_manager.db["app_settings"]` with `CollectionProxy("trips")` and `CollectionProxy("app_settings")` in `admin_api.py`.
- This makes collection resolution lazy so calls always use the active MongoDB client managed by `DatabaseManager`.
- No other API behavior or endpoints were changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3b940c688331969135dc15d68f33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal database collection management to improve system reliability and code quality. These architectural enhancements strengthen the platform's foundation while preserving all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->